### PR TITLE
Change the order between entering the memory_mappped mode and QSPI  read

### DIFF
--- a/SDK/HAL/STM32H750/02-ExtMem_Boot/Core/Src/main.c
+++ b/SDK/HAL/STM32H750/02-ExtMem_Boot/Core/Src/main.c
@@ -157,7 +157,6 @@ int main(void)
 	W25qxx_WriteNoCheck(write,0,sizeof(write));
 	W25qxx_Read(read,0,sizeof(read));
 #endif
-	w25qxx_Startup(w25qxx_DTRMode);
 	
 #if W25Qxx_TEST == (0)
   /* Reset MCU && Long Press K1 to Enter ISP Mode */
@@ -187,6 +186,8 @@ int main(void)
 	
   if(app_IsReady(APPLICATION_ADDRESS) == SUCCESS)
 	{
+		/* Enter memory_mapped mode*/
+		w25qxx_Startup(w25qxx_DTRMode);
 		/* Disable CPU L1 cache before jumping to the QSPI code execution */
 		CPU_CACHE_Disable();
 		/* Disable Systick interrupt */


### PR DESCRIPTION
## Why PR?
After the QSPI controller enters memory_mapped mode, the state variable in the driver will be set to mapped busy, resulting in the inability to use the QSPI controller itself for reads.

## 为什么提交PR？
在QSPI控制器进入内存映射模式后，驱动程序中的状态变量会被置为映射繁忙，导致无法使用QSPI控制器本身进行读取。

